### PR TITLE
[기능 추가] LinkedInventoryBuilder

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.java linguist-language=Kotlin

--- a/InventoryGUI-Plugin/build.gradle.kts
+++ b/InventoryGUI-Plugin/build.gradle.kts
@@ -1,6 +1,0 @@
-group = rootProject.group
-version = rootProject.version
-
-dependencies {
-    implementation(project(":InventoryGUI-api"))
-}

--- a/InventoryGUI-Plugin/src/main/resources/plugin.yml
+++ b/InventoryGUI-Plugin/src/main/resources/plugin.yml
@@ -1,3 +1,3 @@
 name: InventoryGuiLibrary
-version: 4.1.0
+version: 4.2.0
 main: net.projecttl.inventorygui.plugin.InventoryGuiPlugin

--- a/InventoryGUI-api/build.gradle.kts
+++ b/InventoryGUI-api/build.gradle.kts
@@ -3,9 +3,6 @@ plugins {
     signing
 }
 
-group = rootProject.group
-version = rootProject.version
-
 tasks {
     javadoc {
         options.encoding = "UTF-8"
@@ -44,29 +41,29 @@ publishing {
                         password = nexusPassword
                     }
                 }
+            }
 
-                pom {
-                    name.set(rootProject.name)
-                    description.set("This is minecraft gui library")
-                    url.set("https://github.com/DevProject/InventoryGUI")
-                    licenses {
-                        license {
-                            name.set("GNU General Public License Version 3")
-                            url.set("https://www.gnu.org/licenses/gpl-3.0.txt")
-                        }
+            pom {
+                name.set(rootProject.name)
+                description.set("This is minecraft gui library")
+                url.set("https://github.com/DevProject/InventoryGUI")
+                licenses {
+                    license {
+                        name.set("GNU General Public License Version 3")
+                        url.set("https://www.gnu.org/licenses/gpl-3.0.txt")
                     }
-                    developers {
-                        developer {
-                            id.set("DevProject04")
-                            name.set("Dev_Project")
-                            email.set("me@projecttl.net")
-                        }
+                }
+                developers {
+                    developer {
+                        id.set("DevProject04")
+                        name.set("Dev_Project")
+                        email.set("me@projecttl.net")
                     }
-                    scm {
-                        connection.set("scm:git:https://github.com/DevProject04/InventoryGUI.git")
-                        developerConnection.set("scm:git:https://github.com/DevProject04/InventoryGUI.git")
-                        url.set("https://github.com/DevProject04/InventoryGUI.git")
-                    }
+                }
+                scm {
+                    connection.set("scm:git:https://github.com/DevProject04/InventoryGUI.git")
+                    developerConnection.set("scm:git:https://github.com/DevProject04/InventoryGUI.git")
+                    url.set("https://github.com/DevProject04/InventoryGUI.git")
                 }
             }
         }

--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/Animation.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/Animation.kt
@@ -1,20 +1,20 @@
-package net.projecttl.inventory.gui
+package net.projecttl.inventory
 
 import net.kyori.adventure.text.Component
-import net.projecttl.inventory.gui.utils.InventoryType
+import net.projecttl.inventory.InventoryGUI.plugin
+import net.projecttl.inventory.gui.InventoryBuilder
+import net.projecttl.inventory.gui.SimpleInventoryBuilder
+import net.projecttl.inventory.util.InventoryType
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
-import org.bukkit.plugin.java.JavaPlugin
 import java.util.*
 
-fun Player.animatedGui(plugin: JavaPlugin, slotType: InventoryType, title: Component, init: Animation.() -> Unit) : Animation {
-    val a = Animation(this, slotType, title, plugin).apply(init)
-    return a
-}
+/**
+ * Animation!
+ */
+class Animation(val player: Player, val slotType: InventoryType, val title: Component) {
 
-class Animation(val player: Player, val slotType: InventoryType, val title: Component, val plugin: JavaPlugin) {
-
-    lateinit var base: InventoryGuiBuilder
+    lateinit var base: InventoryBuilder
 
     private var running = false
 
@@ -26,15 +26,15 @@ class Animation(val player: Player, val slotType: InventoryType, val title: Comp
     var lastAvailableTicks = -1
 
     // Tick, InventoryGui
-    val frames = TreeMap<Int, InventoryGuiBuilder>()
+    val frames = TreeMap<Int, SimpleInventoryBuilder>()
     var taskId: Int = -1
 
-    fun base(init: InventoryGuiBuilder.() -> Unit) {
-        base = InventoryGuiBuilder(player, slotType, title, plugin).apply(init)
+    fun base(init: SimpleInventoryBuilder.() -> Unit) {
+        base = SimpleInventoryBuilder(player, slotType, title).apply(init)
     }
 
-    fun frame(tick: Int, title: Component = this.title, init: InventoryGuiBuilder.() -> Unit) {
-        frames[tick] = InventoryGuiBuilder(player, slotType, title, plugin).apply(init)
+    fun frame(tick: Int, title: Component = this.title, init: SimpleInventoryBuilder.() -> Unit) {
+        frames[tick] = SimpleInventoryBuilder(player, slotType, title).apply(init)
     }
 
     fun onStop(func: () -> Unit) {

--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/InventoryGUI.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/InventoryGUI.kt
@@ -1,0 +1,67 @@
+package net.projecttl.inventory
+
+import net.kyori.adventure.text.Component
+import net.projecttl.inventory.gui.InventoryBuilder
+import net.projecttl.inventory.gui.SimpleInventoryBuilder
+import net.projecttl.inventory.gui.LinkedInventoryBuilder
+import net.projecttl.inventory.util.InventoryType
+import org.bukkit.entity.Player
+import org.bukkit.inventory.Inventory
+import org.bukkit.plugin.java.JavaPlugin
+import org.bukkit.plugin.java.PluginClassLoader
+import java.util.*
+import kotlin.collections.HashMap
+
+/**
+ * InventoryGUI Data
+ */
+object InventoryGUI {
+    /**
+     * A list of registered inventory id
+     */
+    val inventoryIds = HashMap<UUID, InventoryBuilder>()
+
+    /**
+     * The service plugin. Defaults to the plugin that loaded this library. You can modify this later if you want to
+     */
+    var plugin: JavaPlugin = (javaClass.classLoader as PluginClassLoader).plugin
+}
+
+/**
+ * Opens the default GUI for a player.
+ *
+ * @param title The title of the inventory. This is the text shown at the top of the inventory.
+ * @param slotType The Inventory's Size. Defaults to 27(3 * 9) if not set.
+ * @param init Initialize the inventory builder. Creates a default inventory if not set.
+ *
+ * @return The built inventory
+ */
+fun Player.gui(title: Component, slotType: InventoryType = InventoryType.CHEST_27, init: SimpleInventoryBuilder.() -> Unit = {}): Inventory {
+    return SimpleInventoryBuilder(this, slotType, title).apply(init).build()
+}
+
+/**
+ * Opens a linked GUI for a player. Unlike the default GUI, modifying the LinkedInventoryBuilder observes changes to the builder and modifies the inventory on change. Thus, modifications afterwards in the builder will also be applied to the built inventory.
+ *
+ * @param title The title of the inventory. This is the text shown at the top of the inventory.
+ * @param slotType The Inventory's Size. Defaults to 27(3 * 9) if not set.
+ * @param init Initialize the inventory builder. Creates a default inventory if not set.
+ *
+ * @return The built inventory
+ */
+fun Player.linkedGui(title: Component, slotType: InventoryType = InventoryType.CHEST_27, init: LinkedInventoryBuilder.() -> Unit = {}): Inventory {
+    return LinkedInventoryBuilder(this, slotType, title).apply(init).build()
+}
+
+/**
+ * Creates an animated GUI. Uses the default GUI.
+ *
+ * @param title The title of the inventory. This is the text shown at the top of the inventory.
+ * @param slotType The Inventory's Size. Defaults to 27(3 * 9) if not set.
+ * @param init Initialize the inventory builder. Creates a default inventory if not set.
+ *
+ * @return The built animation
+ */
+fun Player.animatedGui(title: Component, slotType: InventoryType = InventoryType.CHEST_27, init: Animation.() -> Unit = {}) : Animation {
+    return Animation(this, slotType, title).apply(init)
+}

--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/gui/InventoryBuilder.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/gui/InventoryBuilder.kt
@@ -1,0 +1,72 @@
+package net.projecttl.inventory.gui
+
+import net.kyori.adventure.text.Component
+import net.projecttl.inventory.util.InventoryType
+import net.projecttl.inventory.util.Slot
+import org.bukkit.entity.Player
+import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.inventory.Inventory
+import org.bukkit.inventory.ItemStack
+import java.util.*
+import kotlin.collections.HashMap
+
+/**
+ * The abstract implementation of the inventory builder
+ */
+interface InventoryBuilder {
+
+    /**
+     * The owner of this inventory
+     */
+    val player: Player
+
+    /**
+     * The slotType
+     */
+    val slotType: InventoryType
+
+    /**
+     * The title of this inventory
+     */
+    val title: Component
+
+    /**
+     * The inventory id
+     */
+    val id: UUID
+
+    /**
+     * The built inventory
+     */
+    val inventory: Inventory
+
+    /**
+     * The slots
+     */
+    val slots: HashMap<Int, out Slot>
+
+    /**
+     * Builds the current builder into the Bukkit API's Inventory
+     */
+    fun build(): Inventory
+
+    /**
+     * Registers a slot with a click listener
+     */
+    fun slot(slot: Int, item: ItemStack, handler: InventoryClickEvent.() -> Unit)
+
+    /**
+     * Registers a slot
+     */
+    fun slot(slot: Int, item: ItemStack)
+
+    /**
+     * Close inventory for the current player
+     */
+    fun close()
+
+    /**
+     * Destroys the current builder and the built inventory. The inventory will be closed for the player too.
+     */
+    fun destroy()
+}

--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/gui/LinkedInventoryBuilder.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/gui/LinkedInventoryBuilder.kt
@@ -1,0 +1,108 @@
+package net.projecttl.inventory.gui
+
+import net.kyori.adventure.text.Component
+import net.projecttl.inventory.InventoryGUI.inventoryIds
+import net.projecttl.inventory.InventoryGUI.plugin
+import net.projecttl.inventory.util.InventoryType
+import net.projecttl.inventory.util.LinkedSlot
+import net.projecttl.inventory.util.ObservableHashMap
+import net.projecttl.inventory.util.SlotHandler
+import org.bukkit.Bukkit
+import org.bukkit.block.Container
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.inventory.*
+import org.bukkit.event.player.PlayerSwapHandItemsEvent
+import org.bukkit.inventory.Inventory
+import org.bukkit.inventory.ItemStack
+import java.util.*
+
+/**
+ * build 함수 실행 후에도 인벤토리를 수정할 수 있는 InventoryBuilder 입니다.
+ */
+data class LinkedInventoryBuilder(override val player: Player, override val slotType: InventoryType, override val title: Component): Listener,
+    InventoryBuilder {
+
+    override val slots = ObservableHashMap<Int, LinkedSlot>()
+    override val id: UUID = UUID.randomUUID()
+    override lateinit var inventory: Inventory
+        private set
+
+    init {
+        inventoryIds[id] = this
+    }
+
+    override fun slot(slot: Int, item: ItemStack, handler: InventoryClickEvent.() -> Unit) {
+        slots[slot] = LinkedSlot(item, SlotHandler().apply { onClick(handler) })
+    }
+
+    override fun slot(slot: Int, item: ItemStack) {
+        slot(slot, item) {}
+    }
+
+    override fun close() {
+        if (this::inventory.isInitialized)
+            inventory.close()
+    }
+
+    override fun build(): Inventory {
+        inventory = Bukkit.createInventory(null, slotType.size, title)
+
+        for (slot in slots.entries) {
+            inventory.setItem(slot.key, slot.value.stack)
+        }
+
+        slots.addObserver {
+            inventory.setItem(it.first, it.second.stack)
+        }
+
+        player.openInventory(inventory)
+        Bukkit.getServer().pluginManager.registerEvents(this, plugin)
+        return inventory
+    }
+
+    override fun destroy() {
+
+    }
+
+    @EventHandler
+    private fun listener(event: InventoryClickEvent) {
+        if(event.view.title() == this.title) {
+            if (inventoryIds.contains(id) && event.currentItem != null && event.view.player == player) {
+                if (event.inventory == inventory) {
+                    for (slot in slots.entries) {
+                        if (slot.key == event.rawSlot){
+                            event.isCancelled = true
+                            slot.value.handler.click.forEach {
+                                it(event)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @EventHandler
+    private fun listener2(event: InventoryMoveItemEvent) {
+        if (inventoryIds.contains(id) && event.source.holder?.inventory?.viewers?.contains(player)!!
+            && event.source.holder is Container && (event.source.holder as Container).customName() == this.title
+        )
+            event.isCancelled = true
+    }
+
+    @EventHandler
+    private fun listener3(event: InventoryCloseEvent) {
+        if (event.view.player == player && inventoryIds.contains(id))
+            inventoryIds.remove(id)
+    }
+
+    @EventHandler
+    private fun listener4(event: PlayerSwapHandItemsEvent) {
+        if (event.player.inventory == inventory) {
+            event.isCancelled = true
+
+        }
+    }
+}

--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/gui/utils/Slot.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/gui/utils/Slot.kt
@@ -1,6 +1,0 @@
-package net.projecttl.inventory.gui.utils
-
-import org.bukkit.event.inventory.InventoryClickEvent
-import org.bukkit.inventory.ItemStack
-
-data class Slot(val stack: ItemStack, val click: InventoryClickEvent.() -> Unit)

--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/util/InvLocation.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/util/InvLocation.kt
@@ -1,0 +1,6 @@
+package net.projecttl.inventory.util
+
+/**
+ * Descartes coordinate system for inventories
+ */
+data class InvLocation(val x: Int, val y: Int)

--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/util/InventoryType.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/util/InventoryType.kt
@@ -1,7 +1,9 @@
-package net.projecttl.inventory.gui.utils
+package net.projecttl.inventory.util
 
+/**
+ * Inventory Types
+ */
 enum class InventoryType(val size: Int) {
-
     CHEST_9(9),
     CHEST_18(18),
     CHEST_27(27),

--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/util/LinkedSlot.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/util/LinkedSlot.kt
@@ -1,0 +1,8 @@
+package net.projecttl.inventory.util
+
+import org.bukkit.inventory.ItemStack
+
+/**
+ * A slot implementation, for LinkedInventoryBuilders. Unlike Slot, event-handling is separated to SlotHandler
+ */
+class LinkedSlot(stack: ItemStack, val handler: SlotHandler): Slot(stack, {})

--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/util/MathSupport.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/util/MathSupport.kt
@@ -1,0 +1,14 @@
+package net.projecttl.inventory.util
+
+/**
+ * Math in inventories
+ */
+object MathSupport {
+    fun toLocation(index: Int): InvLocation {
+        return InvLocation(index / 9, index % 9)
+    }
+
+    fun toIndex(location: InvLocation): Int {
+        return location.y * 9 + location.x
+    }
+}

--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/util/ObservableHashMap.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/util/ObservableHashMap.kt
@@ -1,0 +1,24 @@
+package net.projecttl.inventory.util
+
+/**
+ * An observable type of hashmaps. Triggers observers on data input.
+ */
+class ObservableHashMap<K, V>: HashMap<K, V>() {
+    private val observers = ArrayList<(Pair<K, V>) -> Unit>()
+
+    fun trigger(key: K, value: V) {
+        observers.forEach {
+            it.invoke(key to value)
+        }
+    }
+
+    fun addObserver(observer: (Pair<K, V>) -> Unit) {
+        observers.add(observer)
+    }
+
+    override fun put(key: K, value: V): V? {
+        val result = super.put(key, value)
+        trigger(key, value)
+        return result
+    }
+}

--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/util/Slot.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/util/Slot.kt
@@ -1,0 +1,9 @@
+package net.projecttl.inventory.util
+
+import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.inventory.ItemStack
+
+/**
+ * Slot for the SimpleInventoryBuilder
+ */
+open class Slot(val stack: ItemStack, val click: InventoryClickEvent.() -> Unit)

--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/util/SlotHandler.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/util/SlotHandler.kt
@@ -1,0 +1,15 @@
+package net.projecttl.inventory.util
+
+import org.bukkit.event.inventory.InventoryClickEvent
+
+/**
+ * Slot Handler for the LinkedSlot.
+ */
+class SlotHandler {
+    @Suppress("WeakerAccess")
+    val click = ArrayList<(InventoryClickEvent) -> Unit>()
+
+    fun onClick(action: (InventoryClickEvent) -> Unit) {
+        click.add(action)
+    }
+}

--- a/InventoryGUI-test/build.gradle.kts
+++ b/InventoryGUI-test/build.gradle.kts
@@ -1,6 +1,0 @@
-group = rootProject.group
-version = rootProject.version
-
-dependencies {
-    implementation(project(":InventoryGUI-api"))
-}

--- a/InventoryGUI-test/src/main/kotlin/net/projecttl/inventorygui/test/InventoryGuiTest.kt
+++ b/InventoryGUI-test/src/main/kotlin/net/projecttl/inventorygui/test/InventoryGuiTest.kt
@@ -2,11 +2,12 @@ package net.projecttl.inventorygui.test
 
 import io.papermc.paper.event.player.AsyncChatEvent
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
-import net.projecttl.inventory.gui.animatedGui
-import net.projecttl.inventory.gui.gui
-import net.projecttl.inventory.gui.utils.InventoryType
+import net.projecttl.inventory.animatedGui
+import net.projecttl.inventory.gui
+import net.projecttl.inventory.util.InventoryType
 import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.event.EventHandler
@@ -19,7 +20,7 @@ class InventoryGuiTest : JavaPlugin(), Listener {
 
     override fun onEnable() {
         server.pluginManager.registerEvents(this, this)
-        Bukkit.getPlayer("")?.gui(this, InventoryType.CHEST_27, Component.text("")) {
+        Bukkit.getPlayer("")?.gui(text("")) {
             slot(1, ItemStack(Material.IRON_INGOT)) {
                 isCancelled = false
             }
@@ -30,7 +31,7 @@ class InventoryGuiTest : JavaPlugin(), Listener {
     fun chat(event: AsyncChatEvent) {
         if(PlainTextComponentSerializer.plainText().serialize(event.message()).contains("animation")) {
             println(PlainTextComponentSerializer.plainText().serialize(event.message()))
-            val anim = event.player.animatedGui(this, InventoryType.CHEST_27, Component.text("Hi", NamedTextColor.GREEN)) {
+            val anim = event.player.animatedGui(text("Hi", NamedTextColor.GREEN)) {
                 base {
                     slot(0, ItemStack(Material.WHITE_STAINED_GLASS_PANE))
                     slot(1, ItemStack(Material.WHITE_STAINED_GLASS_PANE))

--- a/InventoryGUI-test/src/main/resources/plugin.yml
+++ b/InventoryGUI-test/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: InventoryGuiTest
 version: 1.0.0
 main: net.projecttl.inventorygui.test.InventoryGuiTest
-api-version: 1.18
+api-version: 1.17

--- a/InventoryGUI-test/src/main/resources/plugin.yml
+++ b/InventoryGUI-test/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: InventoryGuiTest
 version: 1.0.0
 main: net.projecttl.inventorygui.test.InventoryGuiTest
-api-version: 1.17
+api-version: 1.18

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # InventoryGUI
-This is Minecraft paper gui library.
+A papermc GUI library.
 
-* [Library Feature](https://github.com/ProjectTL12345/InventoryGUI#library-feature)
-* [Library License](https://github.com/ProjectTL12345/InventoryGUI#library-license)
-* [API Build](https://github.com/ProjectTL12345/InventoryGUI#import-library)
-* [How to use this Library](https://github.com/ProjectTL12345/InventoryGUI#how-to-use-this-library)
+* [Features](#Features)
+* [License](#License)
+* [Importing](#import-library)
+* [Usage](#how-to-use-this-library)
 
-## Library Feature
+## Features
 * DSL style code
-* Modular inventory gui with no event declaration required
+* Modular inventory GUI without the requirement of event declaration
 
-## Library License
-This API uses the GPL-3.0 open source license.
-* License: [InventoryGUI License](https://github.com/ProjectTL12345/InventoryGUI/blob/master/LICENSE)
+## License
+This library is licensed under the General Public License v3.0.
+* License: [InventoryGUI License](LICENSE)
 
 ## Import Library
 
@@ -56,9 +56,9 @@ dependencies {
   compileOnly("net.projecttl:InventoryGUI-api:VERSION")
 }
 ```
-Do not shade it! This can installed without shade (latest only feature)!
 
-* Plugin.YML (latest only)
+> If you are using spigot/paper 1.17+, you can use the library-loading feature instead of shading.
+* plugin.yml (1.17+)
 ```
 # ...
 libraries:
@@ -67,18 +67,21 @@ libraries:
 ```
 
 ## How to use this Library
-This api must use kotlin only. (you can use java but it will be hard.)
+This library is kotlin-optimized. DSL pattern will break unless you use kotlin.
 ```Kotlin
-class TestGui(val plugin: JavaPlugin) {
+class TestGui {
   fun inventory(player: Player) {
-    player.gui(plugin, InventoryType.CHEST_27, Component.text("TestGUI")) {
+    player.gui(Component.text("TestGUI"), InventoryType.CHEST_27) {
+        
+        // Prints 'Hello!' when clicked
         slot(0, ItemStack(Material.GRASS_BLOCK)) {
             player.sendMessage("Hello!")
         }
 
-        // dummy slot
+        // Does nothing on click
         slot(1, ItemStack(Material.IRON_INGOT))
     }
   }
 }
 ```
+> More examples [here](InventoryGUI-test/src/main/kotlin/net/projecttl/inventorygui/test/InventoryGuiTest.kt)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ allprojects {
 
     java {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(17))
+            languageVersion.set(JavaLanguageVersion.of(16))
         }
     }
 
@@ -38,7 +38,7 @@ subprojects {
 
     dependencies {
         implementation(kotlin("stdlib"))
-        compileOnly("io.papermc.paper:paper-api:1.18-R0.1-SNAPSHOT")
+        compileOnly("io.papermc.paper:paper-api:1.17.1-R0.1-SNAPSHOT")
         if (this@subprojects.name != "InventoryGUI-api") {
             dependencies {
                 implementation(project(":InventoryGUI-api"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ allprojects {
 
     java {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(16))
+            languageVersion.set(JavaLanguageVersion.of(17))
         }
     }
 
@@ -26,6 +26,9 @@ allprojects {
 }
 
 subprojects {
+    group = rootProject.group
+    version = rootProject.version
+
     repositories {
         maven("https://papermc.io/repo/repository/maven-public/")
         maven(url = "https://oss.sonatype.org/content/repositories/snapshots/") {
@@ -35,8 +38,11 @@ subprojects {
 
     dependencies {
         implementation(kotlin("stdlib"))
-        implementation("net.kyori:adventure-api:4.7.0")
-
-        compileOnly("io.papermc.paper:paper-api:1.17.1-R0.1-SNAPSHOT")
+        compileOnly("io.papermc.paper:paper-api:1.18-R0.1-SNAPSHOT")
+        if (this@subprojects.name != "InventoryGUI-api") {
+            dependencies {
+                implementation(project(":InventoryGUI-api"))
+            }
+        }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### 추가
- LinkedInventoryBuilder
- Documentation
### 수정
- 패키지 분류
    - `net.projecttl.inventory.gui.utils` -> `net.projecttl.inventory.util`
    - `net.projecttl.inventory.gui`에서 몇개는 `net.projecttl.inventory`로 옮겼습니다
- README.md
    - 더 자연스러운 표현으로 바꿨습니다
    - 최신 버전이라는 모호한 표현 대체하였습니다
    - absolute-> relative pathname
- buildscript
    - 중복되는 표현 제거
    - repositories안에 pom을 밖으로 꺼냈습니다( 작동은 하지만 수정했습니다 )
- builder
    - `InventoryGuiBuilder` -> `SimpleInventoryBuilder`
    - `SimpleInventoryBuilder`와 `LinkedInventoryBuilder`은 `InventoryBuilder`을 상속합니다.
    - 기본값 -> CHEST_27 및 빈 init 함수입니다. 이름은 필수입니다
- 플러그인 제공 방식
    - PluginClassLoader을 이용해 자동으로 플러그인 불러오기. 따로 지정할 수도 있습니다.
- dependencies
    - `adventure api`를 따로 불러오지 않아도 됩니다.